### PR TITLE
Solve issue about Windows resolution scale by using Windows API DPI Awareness

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,19 @@
 import pygame
 import os
- 
+import ctypes
+import pandas as pd
+
+# Function to set DPI Awareness 
+def set_dpi_awareness():
+    try:
+        # Try to use the most recent DPI awareness function
+        ctypes.windll.shcore.SetProcessDpiAwareness(2) # 2 = Per Monitor DPI Aware
+    except AttributeError:
+        # If the above function is not available, use the older one
+        ctypes.windll.user32.SetProcessDPIAware()
+
+# DPI Awareness in order to avoid Windows scaling (e.g. "150% recommanded") to break resolution renderer
+set_dpi_awareness()
 
 # Initialize Pygame
 pygame.init()


### PR DESCRIPTION
For same resolution (1080p e.g.), assets and mapping can be outbound due to Windows scaling resolution to 150% or 125% (e.g. when using high resolution laptop screen)
This leads to UI failure and unwanted result. 
To solve this issue I have used Windows API rather than programming registery key modification, this option ajust DPI Awareness only for this game application rather than other workaround, it does not affect the user's registry key or other settings. 
![image](https://github.com/idwessough/iDecisionGame/assets/71006192/9d530b3f-d26f-491d-8acf-202d0a66912f) 
